### PR TITLE
Moving to gpt-4o for better coverage across regions based

### DIFF
--- a/infra/core/ai/openai.bicep
+++ b/infra/core/ai/openai.bicep
@@ -30,7 +30,7 @@ resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01
   parent: account
   name: deployment.name
   sku: {
-    name: 'Standard'
+    name: deployment.skuname
     capacity: deployment.capacity
   }
   properties: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -38,9 +38,9 @@ param chatGptDeploymentVersion string = ''
 param chatGptDeploymentCapacity int = 0
 
 var chatGpt = {
-  modelName: !empty(chatGptModelName) ? chatGptModelName : startsWith(openAiHost, 'azure') ? 'gpt-35-turbo' : 'gpt-3.5-turbo'
+  modelName: !empty(chatGptModelName) ? chatGptModelName : startsWith(openAiHost, 'azure') ? 'gpt-4o' : 'gpt-4o'
   deploymentName: !empty(chatGptDeploymentName) ? chatGptDeploymentName : 'chat'
-  deploymentVersion: !empty(chatGptDeploymentVersion) ? chatGptDeploymentVersion : '0613'
+  deploymentVersion: !empty(chatGptDeploymentVersion) ? chatGptDeploymentVersion : '2024-05-13'
   deploymentCapacity: chatGptDeploymentCapacity != 0 ? chatGptDeploymentCapacity : 40
 }
 
@@ -53,7 +53,7 @@ var embedding = {
   modelName: !empty(embeddingModelName) ? embeddingModelName : 'text-embedding-3-small'
   deploymentName: !empty(embeddingDeploymentName) ? embeddingDeploymentName : 'embeddings'
   deploymentVersion: !empty(embeddingDeploymentVersion) ? embeddingDeploymentVersion : '1'
-  deploymentCapacity: embeddingDeploymentCapacity != 0 ? embeddingDeploymentCapacity : 220
+  deploymentCapacity: embeddingDeploymentCapacity != 0 ? embeddingDeploymentCapacity : 100
   dimensions: embeddingDimensions != 0 ? embeddingDimensions : 1536
 }
 
@@ -138,6 +138,7 @@ module ai 'core/ai/openai.bicep' = {
     deployments: [
       {
         name: embedding.deploymentName
+        skuname: 'Standard'
         capacity: embedding.deploymentCapacity
         model: {
           format: 'OpenAI'
@@ -145,11 +146,12 @@ module ai 'core/ai/openai.bicep' = {
           version: embedding.deploymentVersion
         }
         scaleSettings: {
-          scaleType: 'Standard'
+          scaleType: 'AutoScale'
         }
       }
       {
         name: chatGpt.deploymentName
+        skuname: 'GlobalStandard'
         capacity: chatGpt.deploymentCapacity
         model: {
           format: 'OpenAI'
@@ -157,7 +159,7 @@ module ai 'core/ai/openai.bicep' = {
           version: chatGpt.deploymentVersion
         }
         scaleSettings: {
-          scaleType: 'Standard'
+          scaleType: 'AutoScale'
         }
       }
     ]

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -33,10 +33,10 @@
       "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_CAPACITY}"
     },
     "chatGptDeploymentVersion":{
-      "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION=turbo-2024-04-09}"
+      "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION=2024-05-13}"
     },
     "chatGptModelName":{
-      "value": "${AZURE_OPENAI_CHATGPT_MODEL=gpt-4}"
+      "value": "${AZURE_OPENAI_CHATGPT_MODEL=gpt-4o}"
     },
     "storageAccountName": {
       "value": "${AZURE_STORAGE_ACCOUNT}"


### PR DESCRIPTION
## Purpose
Moving to gpt-4o for better coverage across regions based on https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#global-standard-model-availability

Addresses #4 to give more region coverage
